### PR TITLE
Feature : 페이스북 아이디로 로그인을 위한 Facebook SDK 세팅과 Loginbutton 배치

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId "com.mapzip.ppang.mapzipproject"
-        minSdkVersion 14
+        minSdkVersion 15
         targetSdkVersion 23
         versionCode 5
         versionName "1.5"
@@ -42,6 +42,10 @@ android {
 
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.1.1'
@@ -55,4 +59,5 @@ dependencies {
     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true;
     }
+    compile 'com.facebook.android:facebook-android-sdk:4.10.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,8 @@ android {
         targetSdkVersion 23
         versionCode 5
         versionName "1.5"
+        // Enabling Multidex Support.
+        multiDexEnabled true
     }
     buildTypes {
         release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,11 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mapzip.ppang.mapzipproject">
 
-    <uses-permission android:name="android.permission.INTERNET"></uses-permission>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"></uses-permission>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"></uses-permission>
-    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK"></uses-permission>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".adapter.FontApplication"
@@ -15,28 +15,31 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:theme="@style/AppBaseTheme">
+        <meta-data
+            android:name="com.facebook.sdk.ApplicationId"
+            android:value="@string/facebook_app_id" />
+
         <activity
             android:name=".main.MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme">
-        </activity>
+            android:theme="@style/AppTheme"></activity>
         <activity android:name="com.mapzip.ppang.mapzipproject.main.slidingTap" />
         <activity android:name="com.mapzip.ppang.mapzipproject.map.MapActivity" />
         <activity android:name=".activity.ReviewActivity" />
         <activity android:name=".activity.map_setting" />
         <activity android:name=".activity.review_register" />
         <activity android:name=".activity.addfriend" />
-        <activity android:name=".activity.friend_home"/>
-        <activity android:name="com.mapzip.ppang.mapzipproject.map.SearchInLocationActivity"/>
-        <activity android:name=".activity.suggestActivity"/>
+        <activity android:name=".activity.friend_home" />
+        <activity android:name="com.mapzip.ppang.mapzipproject.map.SearchInLocationActivity" />
+        <activity android:name=".activity.suggestActivity" />
         <activity
             android:name=".main.SplashActivity"
-            android:theme="@android:style/Theme.NoTitleBar"
-            android:hardwareAccelerated="true">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
+            android:hardwareAccelerated="true"
+            android:theme="@android:style/Theme.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
         <!-- [START gcm_receiver] -->
         <receiver

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
             android:value="@string/facebook_app_id" />
 
         <activity
-            android:name=".main.MainActivity"
+            android:name=".ui.account.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme"></activity>
         <activity android:name="com.mapzip.ppang.mapzipproject.main.slidingTap" />
@@ -41,6 +41,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name="com.facebook.FacebookActivity"
+            android:configChanges=
+                "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:label="@string/app_name" />
+
         <!-- [START gcm_receiver] -->
         <receiver
             android:name="com.google.android.gms.gcm.GcmReceiver"

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/adapter/FontApplication.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/adapter/FontApplication.java
@@ -9,6 +9,8 @@ import android.content.Context;
 import android.graphics.Typeface;
 
 import com.crashlytics.android.Crashlytics;
+import com.facebook.appevents.AppEventsLogger;
+
 import io.fabric.sdk.android.Fabric;
 import java.lang.reflect.Field;
 
@@ -18,11 +20,19 @@ public class FontApplication extends Application {
         super.onCreate();
 
         initFabric();
+        AppEventsLogger.activateApp(this);
 
         setDefaultFont(this, "DEFAULT", "default_font2.ttf");
         setDefaultFont(this, "SANS_SERIF", "default_font2.ttf");
         setDefaultFont(this, "SERIF", "default_font2.ttf");
 
+    }
+
+    @Override
+    public void onTerminate() {
+        super.onTerminate();
+
+        AppEventsLogger.deactivateApp(this);
     }
 
     /**

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/adapter/FontApplication.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/adapter/FontApplication.java
@@ -9,22 +9,37 @@ import android.content.Context;
 import android.graphics.Typeface;
 
 import com.crashlytics.android.Crashlytics;
+import com.facebook.CallbackManager;
+import com.facebook.FacebookSdk;
 import com.facebook.appevents.AppEventsLogger;
 
 import io.fabric.sdk.android.Fabric;
 import java.lang.reflect.Field;
 
 public class FontApplication extends Application {
+
+    private Context mGlobalContext;
+    private CallbackManager mCallbackManager;
+
     @Override
     public void onCreate() {
         super.onCreate();
 
+        mGlobalContext = getApplicationContext();
+
         initFabric();
-        AppEventsLogger.activateApp(this);
+        initFacebookSDK();
 
         setDefaultFont(this, "DEFAULT", "default_font2.ttf");
         setDefaultFont(this, "SANS_SERIF", "default_font2.ttf");
         setDefaultFont(this, "SERIF", "default_font2.ttf");
+
+    }
+
+    private void initFacebookSDK() {
+        FacebookSdk.sdkInitialize(mGlobalContext);
+        mCallbackManager = CallbackManager.Factory.create();
+        AppEventsLogger.activateApp(this);
 
     }
 

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/main/SplashActivity.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/main/SplashActivity.java
@@ -4,20 +4,14 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.app.Activity;
 import android.os.Handler;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
-import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
-import android.widget.ProgressBar;
-import android.widget.Toast;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
@@ -25,6 +19,7 @@ import com.mapzip.ppang.mapzipproject.R;
 import com.mapzip.ppang.mapzipproject.gcm.QuickstartPreferences;
 import com.mapzip.ppang.mapzipproject.gcm.RegistrationIntentService;
 import com.mapzip.ppang.mapzipproject.model.UserData;
+import com.mapzip.ppang.mapzipproject.ui.account.MainActivity;
 
 public class SplashActivity extends Activity {
 
@@ -54,19 +49,19 @@ public class SplashActivity extends Activity {
 
         userdata = UserData.getInstance();
 
-        StartImage_ma = (ImageView)findViewById(R.id.start_ma_image);
-        StartImage_flag1 = (ImageView)findViewById(R.id.start_flag1_image);
-        StartImage_zi = (ImageView)findViewById(R.id.start_zi_image);
-        StartImage_flag2 = (ImageView)findViewById(R.id.start_flag2_image);
-        start_text_ani = AnimationUtils.loadAnimation(this,R.anim.start_alpha);
-        start_flag_ani_1 = AnimationUtils.loadAnimation(this,R.anim.start_up2down_1);
-        start_flag_ani_2 = AnimationUtils.loadAnimation(this,R.anim.start_up2down_2);
+        StartImage_ma = (ImageView) findViewById(R.id.start_ma_image);
+        StartImage_flag1 = (ImageView) findViewById(R.id.start_flag1_image);
+        StartImage_zi = (ImageView) findViewById(R.id.start_zi_image);
+        StartImage_flag2 = (ImageView) findViewById(R.id.start_flag2_image);
+        start_text_ani = AnimationUtils.loadAnimation(this, R.anim.start_alpha);
+        start_flag_ani_1 = AnimationUtils.loadAnimation(this, R.anim.start_up2down_1);
+        start_flag_ani_2 = AnimationUtils.loadAnimation(this, R.anim.start_up2down_2);
         StartImage_ma.startAnimation(start_text_ani);
         StartImage_flag1.startAnimation(start_flag_ani_1);
         StartImage_zi.startAnimation(start_text_ani);
         StartImage_flag2.startAnimation(start_flag_ani_2);
         Handler hd = new Handler();
-        hd.postDelayed(new splashhandler(),2500);
+        hd.postDelayed(new splashhandler(), 2500);
     }
 
     @Override
@@ -77,14 +72,14 @@ public class SplashActivity extends Activity {
 
     }
 
-    private class splashhandler implements Runnable{
+    private class splashhandler implements Runnable {
         public void run() {
             startActivity(new Intent(getApplication(), MainActivity.class)); // 로딩이 끝난후 이동할 Activity
             SplashActivity.this.finish(); // 로딩페이지 Activity Stack에서 제거
         }
     }
 
-    private void gcmInit(){
+    private void gcmInit() {
         registBroadcastReceiver();
 
         getInstanceIdToken();
@@ -114,28 +109,28 @@ public class SplashActivity extends Activity {
     /**
      * LocalBroadcast 리시버를 정의한다. 토큰을 획득하기 위한 READY, GENERATING, COMPLETE 액션에 따라 UI에 변화를 준다.
      */
-    private void registBroadcastReceiver(){
+    private void registBroadcastReceiver() {
         mRegistrationBroadcastReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
                 String action = intent.getAction();
 
 
-                if(action.equals(QuickstartPreferences.REGISTRATION_READY)){
+                if (action.equals(QuickstartPreferences.REGISTRATION_READY)) {
                     // 액션이 READY일 경우
                     Log.d(TAG, "GCM 준비완료");
-                } else if(action.equals(QuickstartPreferences.REGISTRATION_GENERATING)){
+                } else if (action.equals(QuickstartPreferences.REGISTRATION_GENERATING)) {
                     // 액션이 GENERATING일 경우
                     Log.d(TAG, "GCM 토큰생성중");
-                } else if(action.equals(QuickstartPreferences.REGISTRATION_COMPLETE)){
+                } else if (action.equals(QuickstartPreferences.REGISTRATION_COMPLETE)) {
                     // 액션이 COMPLETE일 경우
                     Log.d(TAG, "GCM 생성완료" + intent.getStringExtra("token"));
-                }else if(action.equals(QuickstartPreferences.REGISTRATION_NOCHANGE)){
+                } else if (action.equals(QuickstartPreferences.REGISTRATION_NOCHANGE)) {
                     String token = intent.getStringExtra("token");
-                    if(token == null){
-                        Log.d(TAG,"GCM 패키지 변화없음 : gcm token empty");
-                    }else{
-                        Log.d(TAG,"GCM 패키지 변화없음 : "+userdata.getGcm_token());
+                    if (token == null) {
+                        Log.d(TAG, "GCM 패키지 변화없음 : gcm token empty");
+                    } else {
+                        Log.d(TAG, "GCM 패키지 변화없음 : " + userdata.getGcm_token());
                     }
                 }
 
@@ -160,9 +155,4 @@ public class SplashActivity extends Activity {
         }
         return true;
     }
-
-
-
-
-
 }

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/main/setting_Fragment.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/main/setting_Fragment.java
@@ -23,6 +23,7 @@ import com.mapzip.ppang.mapzipproject.activity.suggestActivity;
 import com.mapzip.ppang.mapzipproject.model.SystemMain;
 import com.mapzip.ppang.mapzipproject.model.UserData;
 import com.mapzip.ppang.mapzipproject.network.MyVolley;
+import com.mapzip.ppang.mapzipproject.ui.account.MainActivity;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/ui/account/JoinFragment.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/ui/account/JoinFragment.java
@@ -1,4 +1,4 @@
-package com.mapzip.ppang.mapzipproject.main;
+package com.mapzip.ppang.mapzipproject.ui.account;
 
 import android.content.Context;
 import android.os.Bundle;
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 /**
  * Created by ppangg on 2015-07-31.
  */
-public class joinFragment extends Fragment {
+public class JoinFragment extends Fragment {
 
     private EditText inputID;
     private EditText inputName;
@@ -60,8 +60,8 @@ public class joinFragment extends Fragment {
     private View layout_toast;
     private TextView text_toast;
 
-    public static joinFragment create(int pageNumber) {
-        joinFragment fragment = new joinFragment();
+    public static JoinFragment create(int pageNumber) {
+        JoinFragment fragment = new JoinFragment();
         Bundle args = new Bundle();
         args.putInt("page", pageNumber);
         fragment.setArguments(args);

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/ui/account/LoginFragment.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/ui/account/LoginFragment.java
@@ -1,11 +1,10 @@
-package com.mapzip.ppang.mapzipproject.main;
+package com.mapzip.ppang.mapzipproject.ui.account;
 
 import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.media.Image;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -28,7 +27,13 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.crashlytics.android.answers.Answers;
 import com.crashlytics.android.answers.ContentViewEvent;
+import com.facebook.CallbackManager;
+import com.facebook.FacebookCallback;
+import com.facebook.FacebookException;
+import com.facebook.login.LoginResult;
+import com.facebook.login.widget.LoginButton;
 import com.mapzip.ppang.mapzipproject.R;
+import com.mapzip.ppang.mapzipproject.main.slidingTap;
 import com.mapzip.ppang.mapzipproject.model.SystemMain;
 import com.mapzip.ppang.mapzipproject.model.UserData;
 import com.mapzip.ppang.mapzipproject.network.MyVolley;
@@ -40,7 +45,9 @@ import org.json.JSONObject;
 /**
  * Created by ppangg on 2015-07-31.
  */
-public class loginFragment extends Fragment {
+public class LoginFragment extends Fragment {
+
+    private CallbackManager mCallbackManager;
 
     private boolean lockBtn;
     private LoadingTask Loading;
@@ -48,9 +55,10 @@ public class loginFragment extends Fragment {
     private EditText inputID;
     private EditText inputPW;
     private Button LoginBtn;
+    private LoginButton mLoginButton;
     public UserData user;
     public int map;
-    public ProgressDialog  asyncDialog;
+    public ProgressDialog asyncDialog;
 
     // head
     private ImageView idicon;
@@ -67,14 +75,14 @@ public class loginFragment extends Fragment {
     private CheckBox check_auto;
 
 
-    public static loginFragment create(int pageNumber,int isAuto,String auto_id, String auto_pw) {
+    public static LoginFragment create(int pageNumber, int isAuto, String auto_id, String auto_pw) {
 
-        loginFragment fragment = new loginFragment();
+        LoginFragment fragment = new LoginFragment();
         Bundle args = new Bundle();
         args.putInt("page", pageNumber);
-        args.putInt("isAuto",isAuto);
-        args.putString("auto_id",auto_id);
-        args.putString("auto_pw",auto_pw);
+        args.putInt("isAuto", isAuto);
+        args.putString("auto_id", auto_id);
+        args.putString("auto_pw", auto_pw);
         fragment.setArguments(args);
         return fragment;
     }
@@ -83,16 +91,16 @@ public class loginFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         isAuto = getArguments().getInt("isAuto");
-        if(isAuto == 1){
-            auto_id = getArguments().getString("auto_id","");
-            auto_pw = getArguments().getString("auto_pw","");
+        if (isAuto == 1) {
+            auto_id = getArguments().getString("auto_id", "");
+            auto_pw = getArguments().getString("auto_pw", "");
         }
         res = getResources();
         asyncDialog = new ProgressDialog(this.getActivity());
         user = UserData.getInstance();
 
         Loading = new LoadingTask();
-        lockBtn=false;
+        lockBtn = false;
 
     }
 
@@ -115,7 +123,7 @@ public class loginFragment extends Fragment {
         pwicon.setBackgroundResource(R.drawable.pwicongray);
 
         // Auto_Login CheckBox
-        check_auto = (CheckBox)rootView.findViewById(R.id.check_auto);
+        check_auto = (CheckBox) rootView.findViewById(R.id.check_auto);
         check_auto.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -131,7 +139,7 @@ public class loginFragment extends Fragment {
         inputID.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if(hasFocus)
+                if (hasFocus)
                     idicon.setBackgroundResource(R.drawable.idiconyellow);
                 else
                     idicon.setBackgroundResource(R.drawable.idicongray);
@@ -140,14 +148,14 @@ public class loginFragment extends Fragment {
         inputPW.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if(hasFocus)
+                if (hasFocus)
                     pwicon.setBackgroundResource(R.drawable.pwiconyellow);
                 else
                     pwicon.setBackgroundResource(R.drawable.pwicongray);
             }
         });
 
-        if(user.getIsAuto() == 1){
+        if (user.getIsAuto() == 1) {
             check_auto.setChecked(true);
             inputID.setText(auto_id);
             inputPW.setText(auto_pw);
@@ -156,14 +164,53 @@ public class loginFragment extends Fragment {
         LoginBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-             if(lockBtn==false) {
-                 lockBtn = true;
-                 DoLogin(v);
-             }
+                if (lockBtn == false) {
+                    lockBtn = true;
+                    DoLogin(v);
+                }
             }
         });
 
         return rootView;
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        setFacebookLogin(view);
+    }
+
+    private void setFacebookLogin(View view) {
+        mCallbackManager = CallbackManager.Factory.create();
+
+        mLoginButton = (LoginButton) view.findViewById(R.id.button_fb_login);
+        mLoginButton.setReadPermissions("public_profile");
+        mLoginButton.setFragment(this);
+        mLoginButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mLoginButton.registerCallback(mCallbackManager, new FacebookCallback<LoginResult>() {
+                    @Override
+                    public void onSuccess(LoginResult loginResult) {
+                        Log.i("LoginFragment", "onSuccess");
+                        Log.i("LoginFragment", loginResult.getAccessToken().getUserId());
+                    }
+
+                    @Override
+                    public void onCancel() {
+                        Log.i("LoginFragment", "onCancel");
+
+                    }
+
+                    @Override
+                    public void onError(FacebookException error) {
+                        Log.i("LoginFragment", "onError");
+
+                    }
+                });
+            }
+        });
     }
 
     @SuppressLint("LongLogTag")
@@ -177,9 +224,9 @@ public class loginFragment extends Fragment {
 
         if (userid != null && !userid.equals("") && userpw != null && !userpw.equals("")) {
 
-            InputMethodManager imm = (InputMethodManager)getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+            InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.hideSoftInputFromWindow(inputPW.getWindowToken(), 0);
-            InputMethodManager imm2 = (InputMethodManager)getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+            InputMethodManager imm2 = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.hideSoftInputFromWindow(inputID.getWindowToken(), 0);
 
             JSONObject obj = new JSONObject();
@@ -225,19 +272,19 @@ public class loginFragment extends Fragment {
                         map = mapcount;
 
                         // 지도 순서 맞추기
-                        int metaorder[] = new int[mapcount+1];
+                        int metaorder[] = new int[mapcount + 1];
                         metaorder[0] = -1;
-                        for(int i=0; i<mapcount; i++){
+                        for (int i = 0; i < mapcount; i++) {
                             metaorder[Integer.parseInt(response.getJSONArray("mapmeta_info").getJSONObject(i).getString("map_id"))] = i;
                         }
 
                         JSONArray newmetaarr = new JSONArray();
-                        for(int j=1; j<metaorder.length; j++){
+                        for (int j = 1; j < metaorder.length; j++) {
                             newmetaarr.put(response.getJSONArray("mapmeta_info").getJSONObject(metaorder[j]));
                         }
 
                         user.setMapmetaArray(newmetaarr);
-                        Log.v("맵메타",String.valueOf(user.getMapmetaArray()));
+                        Log.v("맵메타", String.valueOf(user.getMapmetaArray()));
 
                         JSONObject jar = response.getJSONObject("gu_enroll_num");
                         Log.v("구넘버", String.valueOf(jar));
@@ -267,8 +314,7 @@ public class loginFragment extends Fragment {
                             }
                         }
 
-                           Loading.execute();
-
+                        Loading.execute();
 
 
                         // toast
@@ -278,7 +324,7 @@ public class loginFragment extends Fragment {
                         toast.setView(layout_toast);
                         toast.show();
                         sendLoginSuccessToAnswers();
-                    } else if(response.get("state").toString().equals("201")) {
+                    } else if (response.get("state").toString().equals("201")) {
                         // toast
                         text_toast.setText("존재하지 않는 계정정보입니다.");
                         Toast toast = new Toast(getActivity());
@@ -290,7 +336,7 @@ public class loginFragment extends Fragment {
                     Log.v("에러", "제이손");
                 }
 
-                lockBtn =false;
+                lockBtn = false;
             }
         };
     }
@@ -316,16 +362,17 @@ public class loginFragment extends Fragment {
                     toast.setView(layout_toast);
                     toast.show();
 
-                    Log.e("loginFragment", error.getMessage());
+                    Log.e("LoginFragment", error.getMessage());
                 } catch (NullPointerException ex) {
                     // toast
-                    Log.e("loginFragment", "nullpointexception");
+                    Log.e("LoginFragment", "nullpointexception");
                 }
 
-                lockBtn =false;
+                lockBtn = false;
             }
         };
     }
+
     protected class LoadingTask extends AsyncTask<Void, Void, Void> {
 
         @Override
@@ -343,8 +390,8 @@ public class loginFragment extends Fragment {
         @Override
         protected Void doInBackground(Void... arg0) {
             for (int mapnum = 1; mapnum <= map; mapnum++)
-            user.setMapImage(mapnum, res);
-         return null;
+                user.setMapImage(mapnum, res);
+            return null;
         }
 
 
@@ -360,7 +407,6 @@ public class loginFragment extends Fragment {
 
             super.onPostExecute(result);
         }
-
 
 
     }

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/ui/account/MainActivity.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/ui/account/MainActivity.java
@@ -1,4 +1,4 @@
-package com.mapzip.ppang.mapzipproject.main;
+package com.mapzip.ppang.mapzipproject.ui.account;
 
 import android.app.AlertDialog;
 import android.content.SharedPreferences;
@@ -98,9 +98,9 @@ public class MainActivity extends FragmentActivity {
         public Fragment getItem(int position) {
             // �ش��ϴ� page�� Fragment�� �����մϴ�.
             if(position == 0)
-                return joinFragment.create(position);
+                return JoinFragment.create(position);
             else
-                return loginFragment.create(position,isAuto,auto_id,auto_pw);
+                return LoginFragment.create(position, isAuto, auto_id, auto_pw);
 
         }
 

--- a/app/src/main/res/layout/join_layout.xml
+++ b/app/src/main/res/layout/join_layout.xml
@@ -155,7 +155,6 @@
                     android:enabled="false" />
 
             </RelativeLayout>
-
         </RelativeLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/login_layout.xml
+++ b/app/src/main/res/layout/login_layout.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:gravity="center"
-    android:background="@drawable/loginbg"
     android:layout_height="match_parent"
+    android:background="@drawable/loginbg"
     android:focusable="true"
     android:focusableInTouchMode="true"
-    >
+    android:gravity="center"
+    android:orientation="vertical">
 
     <ImageView
-        android:layout_marginTop="20dp"
+        android:id="@+id/mapziplogo"
         android:layout_width="350dp"
         android:layout_height="140dp"
-        android:id="@+id/mapziplogo"
-        android:src="@drawable/loginmapzip"
-        android:layout_marginBottom="100dp"/>
+        android:layout_marginBottom="100dp"
+        android:layout_marginTop="20dp"
+        android:src="@drawable/loginmapzip" />
 
     <RelativeLayout
         android:id="@+id/loginid"
@@ -25,20 +24,19 @@
         android:background="@drawable/logintxtbg">
 
         <ImageView
-            android:layout_width="60dp"
-            android:layout_height="match_parent"
             android:id="@+id/idicon"
-            />
+            android:layout_width="60dp"
+            android:layout_height="match_parent" />
 
         <EditText
+            android:id="@+id/InputID"
             android:layout_width="230dp"
             android:layout_height="match_parent"
-            android:id="@+id/InputID"
-            android:background="@color/transparent"
-            android:singleLine="true"
-            android:maxLength="15"
             android:layout_marginLeft="60dp"
-            android:hint="ID" />
+            android:background="@color/transparent"
+            android:hint="ID"
+            android:maxLength="15"
+            android:singleLine="true" />
 
     </RelativeLayout>
 
@@ -47,59 +45,64 @@
         android:layout_width="290dp"
         android:layout_height="46dp"
         android:layout_centerHorizontal="true"
-        android:background="@drawable/logintxtbg"
-        android:layout_marginTop="3dp">
+        android:layout_marginTop="3dp"
+        android:background="@drawable/logintxtbg">
 
         <ImageView
-            android:layout_width="60dp"
-            android:layout_height="match_parent"
             android:id="@+id/pwicon"
-            />
+            android:layout_width="60dp"
+            android:layout_height="match_parent" />
 
         <EditText
-        android:layout_width="230dp"
-        android:layout_height="match_parent"
-        android:inputType="textPassword"
-        android:id="@+id/InputPW"
-        android:background="@color/transparent"
-        android:hint="PW"
-        android:maxLength="15"
-        android:layout_marginLeft="60dp"
-        android:singleLine="true"
-        />
+            android:id="@+id/InputPW"
+            android:layout_width="230dp"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="60dp"
+            android:background="@color/transparent"
+            android:hint="PW"
+            android:inputType="textPassword"
+            android:maxLength="15"
+            android:singleLine="true" />
 
     </RelativeLayout>
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:layout_marginTop="20dp">
+        android:layout_marginTop="20dp"
+        android:gravity="center">
 
-    <Button
-        android:layout_width="290dp"
-        android:layout_height="48dp"
-        android:background="@drawable/loginbtn"
-        android:id="@+id/btnLogin" />
+        <Button
+            android:id="@+id/btnLogin"
+            android:layout_width="290dp"
+            android:layout_height="48dp"
+            android:background="@drawable/loginbtn" />
 
-    <CheckBox
-        android:id="@+id/check_auto"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/btnLogin"
-        android:text="자동 로그인"/>
+        <CheckBox
+            android:id="@+id/check_auto"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/btnLogin"
+            android:text="자동 로그인" />
+
+        <com.facebook.login.widget.LoginButton
+            android:id="@+id/button_fb_login"
+            android:layout_width="290dp"
+            android:layout_height="48dp"
+            android:layout_below="@id/check_auto"
+            android:layout_marginTop="20dp" />
 
     </RelativeLayout>
 
     <TextView
         android:id="@+id/TextState"
-        android:layout_marginTop="40dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:layout_marginTop="40dp"
+        android:text="> 밀어서 가입하기"
         android:textColor="@color/textbrown"
-        android:textStyle="bold"
         android:textSize="20sp"
-        android:text="> 밀어서 가입하기"/>
+        android:textStyle="bold" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="facebook_app_id">443487665850615</string>
 
     <string name="app_name">MapZip</string>
     <string name="action_settings">Settings</string>


### PR DESCRIPTION
유저들이 자신의 맛집 지도를 지인들에게 널리 알림으로서, 우리의 서비스가 더 넓은 영역으로 퍼질수 있습니다.

그러기위해서는 Facebook을 이용한 콘텐츠 공유가 꼭 필요한 기능이라고 생각하였고, 그것을 위해서는 우선 유저들이 자신의 Facebook 계정으로 서비스에 접근하는것이 가능해야합니다.

본 Pull Request는 그 기능을 개발하기전에 이 프로젝트에 **Facebook SDK과 Facebook LoginButton을 세팅하는 내용**이 담겨있습니다.

**아울러 프로젝트의 구조를 앞으로 조금씩 더 한눈에 들어오고, 가독성있게끔 하기위해 프로젝트의 디렉토리를 점차 수정해나가려합니다.**

기존에 `main/joinFragment, main/loginFragment, main/MainActivity`에 위치해있던것을, `ui/account`라는 폴더를 만들어서 그곳에 위치시켰습니다.

한 기능에대해서 구현을 담고있는 클래스 파일은 그 기능을 account 라는 형식처럼 간단하게 대변할수있는 디렉토리가 따로 담고있어야 프로젝트를 처음 접하는 다른 개발자가 쉽게 접근하고 이해할수 있다고 생각합니다.

코드 정렬때문에 쓸모없는 부분의 수정이 많습니다.

주로 `app/build.gradle / AndroidManifest / FontApplication / JoinFragment / LoginFragment / login_layout.xml / strings.xml` 을 봐주시면 됩니다.

이전에 풀리퀘스트를 올린것이 아직도 리뷰가 안되었지만 다 천천히 진행될것이라 생각하고 이 변경사항도 리뷰 부탁드립니다.